### PR TITLE
Add minimal sprite example

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,18 @@ Compiling with support for SDL requires additional compilation steps. First the 
 
 Compiling with support for the tiny3d render device requires the user to compile with support for C++11 threading (STL). Some systems (Linux with g++) require the user to link against ```pthread``` or else the compilation will fail under the linking stage.
 
+## Examples
+A minimal example showing a sprite is available in `examples/minimal`.
+
+```
+cd examples/minimal
+make
+./minimal_example
+```
+
+Ensure SDL2 development files are installed. Define `RETRO3D_USE_SDL1` instead of `RETRO3D_USE_SDL2` if using SDL1.
+
+
 ## Credits
 
 The images and videos above include content from the following creators:

--- a/examples/minimal/Makefile
+++ b/examples/minimal/Makefile
@@ -1,0 +1,11 @@
+CXX = g++
+SRC = $(shell find ../.. -name '*.cpp')
+CXXFLAGS = -std=c++11 -I../.. $(shell sdl2-config --cflags) -DRETRO3D_USE_SDL2
+LDFLAGS = -lpthread $(shell sdl2-config --libs) -lSDL2_mixer
+TARGET = minimal_example
+
+all:
+	$(CXX) $(CXXFLAGS) $(SRC) -o $(TARGET) $(LDFLAGS)
+
+clean:
+	rm -f $(TARGET)

--- a/examples/minimal/main.cpp
+++ b/examples/minimal/main.cpp
@@ -1,0 +1,26 @@
+#include "retro3d.h"
+#include "backend/sdl_video_device.h"
+#include "backend/sdl_input_device.h"
+#include "backend/sdl_sound_device.h"
+#include "backend/t3d_render_device.h"
+#include "sprite_component.h"
+
+int main()
+{
+    retro3d::Engine engine;
+
+    engine.CreateRenderDevice<platform::T3DRenderDevice>();
+    engine.CreateSoundDevice<platform::SDLSoundDevice>();
+    engine.CreateInputDevice<platform::SDLInputDevice>();
+    engine.CreateVideoDevice<platform::SDLVideoDevice>();
+
+    engine.GetVideo()->CreateWindow(640, 480, false);
+    engine.GetRenderer()->CreateRenderSurface(640, 480);
+    engine.GetRenderer()->SetDepthClip(0.1f, 100.0f, 90.0f);
+
+    retro3d::Entity* e = engine.SpawnEntity();
+    e->AddComponent<examples::SpriteComponent>();
+
+    engine.Run();
+    return 0;
+}

--- a/examples/minimal/sprite_component.cpp
+++ b/examples/minimal/sprite_component.cpp
@@ -1,0 +1,3 @@
+#include "sprite_component.h"
+
+namespace examples { retro_register_component(SpriteComponent) }

--- a/examples/minimal/sprite_component.h
+++ b/examples/minimal/sprite_component.h
@@ -1,0 +1,33 @@
+#ifndef EXAMPLES_MINIMAL_SPRITE_COMPONENT_H
+#define EXAMPLES_MINIMAL_SPRITE_COMPONENT_H
+
+#include "retro3d.h"
+#include "ecs/components/retro_transform_component.h"
+#include "graphics/retro_model.h"
+
+namespace examples
+{
+
+retro_component(SpriteComponent)
+{
+private:
+    retro3d::SharedTransform m_transform;
+    mtlShared<retro3d::Model> m_model;
+protected:
+    void OnSpawn(void) override
+    {
+        m_transform = GetObject()->AddComponent<retro3d::TransformComponent>()->GetTransform();
+        m_model = retro3d::Model::Library.Fetch("Default.Plane.Model");
+    }
+    void OnUpdate(void) override
+    {
+        GetRenderer()->RenderSpritePlane(*m_model.GetShared(), m_transform->GetFinalMatrix(),
+                                         retro3d::RenderDevice::LightMode_Dynamic);
+    }
+public:
+    SpriteComponent(void) : mtlInherit(this), m_transform(), m_model() {}
+};
+
+}
+
+#endif // EXAMPLES_MINIMAL_SPRITE_COMPONENT_H


### PR DESCRIPTION
## Summary
- add a minimal example that displays a sprite using SDL and the tiny3d renderer
- provide a simple Makefile for building the example
- document the example in the README

## Testing
- `make -C examples/minimal --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_683f9908a1c48328b082b7f4ef1e1b63